### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,14 +63,14 @@
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^10.0.0",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@types/node": "^20",
     "@types/nodemailer": "^6.4.15",
     "@types/react": "^18",
     "@types/react-beautiful-dnd": "^13.1.8",
-    
     "@types/react-dom": "^18",
     "@types/uuid": "^10.0.0",
     "genkit-cli": "^1.8.0",

--- a/src/components/recipe/RecipeForm.tsx
+++ b/src/components/recipe/RecipeForm.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import DOMPurify from "dompurify";
 import { useRouter } from "next/navigation";
 import { useForm, useFieldArray, type Control } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -620,7 +621,7 @@ export function RecipeForm({ initialData, isEditMode = false }: RecipeFormProps)
                 <CardContent className="space-y-3">
                     {imagePreview && (
                         <div className="relative group">
-                            <img src={imagePreview} alt={t('image_preview_alt')} className="rounded-md object-cover border w-full aspect-[16/9]" data-ai-hint="food cooking recipe"/>
+                            <img src={DOMPurify.sanitize(imagePreview)} alt={t('image_preview_alt')} className="rounded-md object-cover border w-full aspect-[16/9]" data-ai-hint="food cooking recipe"/>
                             <Button type="button" variant="destructive" size="icon" className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity" onClick={handleClearImage} aria-label={t('remove_image_button')}>
                                 <XCircle className="h-5 w-5"/>
                             </Button>


### PR DESCRIPTION
Potential fix for [https://github.com/torfinnnome/oppskrift/security/code-scanning/1](https://github.com/torfinnnome/oppskrift/security/code-scanning/1)

To fix the issue, we need to ensure that the `imagePreview` variable is sanitized before being used in the `src` attribute of the `<img>` tag. This can be achieved by:
1. Validating the URL more strictly to ensure it is safe and does not contain malicious content.
2. Escaping the `imagePreview` value before using it in the DOM to prevent XSS attacks.

The best approach is to use a library like `DOMPurify` to sanitize the URL before assigning it to `imagePreview`. This ensures that any potentially harmful content is removed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
